### PR TITLE
Implement set/get curl options methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -150,6 +150,28 @@ class Client implements ClientInterface
     }
 
     /**
+     * Manipulate $curlOptions array
+     *
+     * @param array $curlOptions
+     *
+     * @return void
+     */
+    public function setCurlOptions(array $curlOptions) : void
+    {
+        $this->curlOptions = $this->curlOptions + $curlOptions;
+    }
+
+    /**
+     * Get protected $curlOptions array
+     *
+     * @return array
+     */
+    public function getCurlOptions() : array
+    {
+        return $this->curlOptions;
+    }
+
+    /**
      * Supplements options for a cURL session from the given request message
      *
      * @param RequestInterface $request
@@ -160,16 +182,19 @@ class Client implements ClientInterface
     {
         $options = $this->curlOptions;
 
-        $options[CURLOPT_RETURNTRANSFER] = true;
-        $options[CURLOPT_HEADER]         = true;
-        $options[CURLOPT_CUSTOMREQUEST]  = $request->getMethod();
-        $options[CURLOPT_URL]            = (string) $request->getUri();
-        $options[CURLOPT_POSTFIELDS]     = (string) $request->getBody();
+        $options[CURLOPT_RETURNTRANSFER] = $options[CURLOPT_RETURNTRANSFER] ?? true;
+        $options[CURLOPT_HEADER]         = $options[CURLOPT_HEADER] ?? true;
+        $options[CURLOPT_CUSTOMREQUEST]  = $options[CURLOPT_CUSTOMREQUEST] ?? $request->getMethod();
+        $options[CURLOPT_URL]            = $options[CURLOPT_URL] ?? (string) $request->getUri();
+        $options[CURLOPT_POSTFIELDS]     = $options[CURLOPT_POSTFIELDS] ?? (string) $request->getBody();
+        $options[CURLOPT_HTTPHEADER]     = $options[CURLOPT_HTTPHEADER] ?? [];
 
         foreach ($request->getHeaders() as $name => $values) {
             foreach ($values as $value) {
                 $header = sprintf('%s: %s', $name, $value);
-                $options[CURLOPT_HTTPHEADER][] = $header;
+                if (!in_array($header, $options[CURLOPT_HTTPHEADER])) {
+                    $options[CURLOPT_HTTPHEADER][] = $header;
+                }
             }
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,6 +17,10 @@ use Sunrise\Http\Factory\RequestFactory;
 use Sunrise\Http\Factory\ResponseFactory;
 use Sunrise\Http\Factory\StreamFactory;
 
+use const CURLOPT_URL;
+use const CURLOPT_POST;
+use const CURLOPT_HEADER;
+
 class ClientTest extends TestCase
 {
     public function testConstructor()
@@ -95,5 +99,30 @@ class ClientTest extends TestCase
         $this->assertEquals($message, $exception->getMessage());
         $this->assertEquals($code, $exception->getCode());
         $this->assertEquals($previous, $exception->getPrevious());
+    }
+
+    public function testSetCurlOptions()
+    {
+        $client = new Client(new ResponseFactory(), new StreamFactory());
+        $curlOptions = [
+            CURLOPT_URL => 'https://github.com',
+            CURLOPT_POST => true,
+            CURLOPT_HEADER => false,
+        ];
+        $client->setCurlOptions($curlOptions);
+
+        $this->assertEquals($curlOptions, $client->getCurlOptions());
+    }
+
+    public function testGetCurlOptions()
+    {
+        $curlOptions = [
+            CURLOPT_URL => 'https://github.com',
+            CURLOPT_POST => true,
+            CURLOPT_HEADER => false,
+        ];
+        $client = new Client(new ResponseFactory(), new StreamFactory(), $curlOptions);
+
+        $this->assertEquals($curlOptions, $client->getCurlOptions());
     }
 }


### PR DESCRIPTION
# Changed log
- It's related to issue #2.
- Implement the set and get curl options to avoid overriding the protected `$curlOptions` variable.
- Using the `??` syntax to check whether the specific CURL options are existed on `Client::padCurlOptions` method.