### PR TITLE
provide psr/http-client-implementation version 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "sunrise/http-factory": "1.0.6"
     },
     "provide": {
+        "psr/http-client-implementation": "1.0",
         "php-http/client-implementation": "1.0"
     },
     "autoload": {


### PR DESCRIPTION
Closes #12 

The doubt about providing `"^1.0"` or `"1.0"` make me read a lot about composer and packagist virtual packages and found that there are no defined rules for `provides` section related to version constraints.

What I found is that PHP-FIG have a convention to use exact versions for implementations:
https://www.php-fig.org/bylaws/psr-naming-conventions/

> ... Implementors of that PSR can then provide `"psr/<package>-implementation": "1.0.0"` in their package to satisfy that requirement ...